### PR TITLE
Support for kubernetes version 1.22

### DIFF
--- a/charts/nodepool-labels-operator/Chart.yaml
+++ b/charts/nodepool-labels-operator/Chart.yaml
@@ -2,4 +2,4 @@ name: nodepool-labels-operator
 description: Banzai K8s Nodepool Labels Operator
 apiVersion: v2
 appVersion: 0.1.1
-version: 0.2.3
+version: 0.2.4

--- a/charts/nodepool-labels-operator/Chart.yaml
+++ b/charts/nodepool-labels-operator/Chart.yaml
@@ -2,4 +2,4 @@ name: nodepool-labels-operator
 description: Banzai K8s Nodepool Labels Operator
 apiVersion: v2
 appVersion: 0.1.1
-version: 0.1.2
+version: 0.2.1

--- a/charts/nodepool-labels-operator/Chart.yaml
+++ b/charts/nodepool-labels-operator/Chart.yaml
@@ -2,4 +2,4 @@ name: nodepool-labels-operator
 description: Banzai K8s Nodepool Labels Operator
 apiVersion: v2
 appVersion: 0.1.1
-version: 0.1.1
+version: 0.1.2

--- a/charts/nodepool-labels-operator/Chart.yaml
+++ b/charts/nodepool-labels-operator/Chart.yaml
@@ -2,4 +2,4 @@ name: nodepool-labels-operator
 description: Banzai K8s Nodepool Labels Operator
 apiVersion: v2
 appVersion: 0.1.1
-version: 0.2.4
+version: 0.2.5

--- a/charts/nodepool-labels-operator/Chart.yaml
+++ b/charts/nodepool-labels-operator/Chart.yaml
@@ -2,4 +2,4 @@ name: nodepool-labels-operator
 description: Banzai K8s Nodepool Labels Operator
 apiVersion: v2
 appVersion: 0.1.1
-version: 0.2.1
+version: 0.2.3

--- a/charts/nodepool-labels-operator/README.md
+++ b/charts/nodepool-labels-operator/README.md
@@ -2,6 +2,8 @@
 
 ## Installing the operator
 
+>Supported Kubernetes versions: >= 1.16.
+
 ```bash
 helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
 helm repo update

--- a/charts/nodepool-labels-operator/templates/crd.yml
+++ b/charts/nodepool-labels-operator/templates/crd.yml
@@ -1,5 +1,11 @@
 ---
+{{- $major := .Capabilities.KubeVersion.Major -}}
+{{- $minor := .Capabilities.KubeVersion.Minor -}}
+{{- if and (eq (int $major) 1) (ge (int $minor) 16) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: nodepoollabelsets.labels.banzaicloud.io

--- a/charts/nodepool-labels-operator/templates/crd.yml
+++ b/charts/nodepool-labels-operator/templates/crd.yml
@@ -30,5 +30,7 @@ spec:
               properties:
                 labels:
                   type: object
+                  additionalProperties:
+                    type: string
       served: true
       storage: true

--- a/charts/nodepool-labels-operator/templates/crd.yml
+++ b/charts/nodepool-labels-operator/templates/crd.yml
@@ -3,6 +3,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nodepoollabelsets.labels.banzaicloud.io
+  labels:
+    app: { { include "nodepool-labels-operator.name" . } }
+    chart: { { include "nodepool-labels-operator.chart" . } }
+    release: { { .Release.Name } }
+    heritage: { { .Release.Service } }
 spec:
   group: labels.banzaicloud.io
   scope: Namespaced

--- a/charts/nodepool-labels-operator/templates/crd.yml
+++ b/charts/nodepool-labels-operator/templates/crd.yml
@@ -30,9 +30,5 @@ spec:
               properties:
                 labels:
                   type: object
-                  additionalProperties:
-                    type: string
-                  minProperties: 1
-                  maxProperties: 1
       served: true
       storage: true

--- a/charts/nodepool-labels-operator/templates/crd.yml
+++ b/charts/nodepool-labels-operator/templates/crd.yml
@@ -4,10 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   name: nodepoollabelsets.labels.banzaicloud.io
   labels:
-    app: { { include "nodepool-labels-operator.name" . } }
-    chart: { { include "nodepool-labels-operator.chart" . } }
-    release: { { .Release.Name } }
-    heritage: { { .Release.Service } }
+    app: {{ include "nodepool-labels-operator.name" . }}
+    chart: {{ include "nodepool-labels-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: labels.banzaicloud.io
   scope: Namespaced

--- a/charts/nodepool-labels-operator/templates/crd.yml
+++ b/charts/nodepool-labels-operator/templates/crd.yml
@@ -1,22 +1,10 @@
 ---
-{{- $major := .Capabilities.KubeVersion.Major -}}
-{{- $minor := .Capabilities.KubeVersion.Minor -}}
-{{- if and (eq (int $major) 1) (ge (int $minor) 16) }}
 apiVersion: apiextensions.k8s.io/v1
-{{- else }}
-apiVersion: apiextensions.k8s.io/v1beta1
-{{- end }}
 kind: CustomResourceDefinition
 metadata:
   name: nodepoollabelsets.labels.banzaicloud.io
-  labels:
-    app: {{ include "nodepool-labels-operator.name" . }}
-    chart: {{ include "nodepool-labels-operator.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
 spec:
   group: labels.banzaicloud.io
-  version: v1alpha1
   scope: Namespaced
   names:
     kind: NodePoolLabelSet
@@ -24,3 +12,22 @@ spec:
     singular: nodepoollabelset
     shortNames:
       - npls
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
+          properties:
+            spec:
+              type: object
+              required: [ "labels" ]
+              properties:
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  minProperties: 1
+                  maxProperties: 1
+      served: true
+      storage: true

--- a/deploy/crd.yml
+++ b/deploy/crd.yml
@@ -5,7 +5,6 @@ metadata:
   name: nodepoollabelsets.labels.banzaicloud.io
 spec:
   group: labels.banzaicloud.io
-  version: v1alpha1
   scope: Namespaced
   names:
     kind: NodePoolLabelSet
@@ -13,16 +12,22 @@ spec:
     singular: nodepoollabelset
     shortNames:
       - npls
-  validation:
-    openAPIV3Schema:
-      required: ["spec"]
-      properties:
-        spec:
-          required: [ "labels" ]
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: ["spec"]
           properties:
-            labels:
+            spec:
               type: object
-              additionalProperties:
-                type: string
-              minProperties: 1
-              maxProperties: 1
+              required: [ "labels" ]
+              properties:
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  minProperties: 1
+                  maxProperties: 1
+      served: true
+      storage: true

--- a/deploy/crd.yml
+++ b/deploy/crd.yml
@@ -25,9 +25,5 @@ spec:
               properties:
                 labels:
                   type: object
-                  additionalProperties:
-                    type: string
-                  minProperties: 1
-                  maxProperties: 1
       served: true
       storage: true

--- a/deploy/crd.yml
+++ b/deploy/crd.yml
@@ -25,5 +25,7 @@ spec:
               properties:
                 labels:
                   type: object
+                  additionalProperties:
+                    type: string
       served: true
       storage: true

--- a/deploy/crd.yml
+++ b/deploy/crd.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: nodepoollabelsets.labels.banzaicloud.io


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #23
| License         | Apache 2.0


### What's in this PR?
Replace admissionregistration.k8s.io/v1beta1 not available from version 1.22 with admissionregistration.k8s.io/v1 available from version 1.16.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
