### PR TITLE
Fixed Helm push command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           helm package "charts/${CHART_NAME}"
           tgz="$(find '.' -name '*.tgz')"
-          helm push "${tgz}" chartmuseum
+          helm cm-push "${tgz}" chartmuseum
         env:
           HELM_REPO_USERNAME: ${{ secrets.HELM_REPO_USERNAME }}
           HELM_REPO_PASSWORD: ${{ secrets.HELM_REPO_PASSWORD }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Changed helm `push` command to `cm-push`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The `push` command is now built-in as of helm 3.7.0 so the `helm-push` plugin changed its command name to `cm-push`.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

We just pull the latest `helm-push` plugin during the chart publishing pipeline, which broke because of this the last time it was used.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~